### PR TITLE
Add a test on load visibility for //private bzl.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,6 +38,7 @@ bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.5.0", dev_dependency = True)
 
 autodetected_toolchain_repo = use_repo_rule("//devicetree/private:autodetected_toolchain_repo.bzl", "autodetected_toolchain_repo")
 

--- a/devicetree/defs.bzl
+++ b/devicetree/defs.bzl
@@ -1,0 +1,5 @@
+"Public API re-exports"
+
+def example():
+    """This is an example"""
+    pass

--- a/devicetree/private/BUILD.bazel
+++ b/devicetree/private/BUILD.bazel
@@ -35,3 +35,9 @@ bzl_library(
         ":devicetree_toolchain_info",
     ],
 )
+
+filegroup(
+    name = "all_bzl_files",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//devicetree/tests:__subpackages__"],
+)

--- a/devicetree/tests/load_visibility_test/BUILD.bazel
+++ b/devicetree/tests/load_visibility_test/BUILD.bazel
@@ -1,0 +1,22 @@
+# Copyright (C) 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_test")
+
+py_test(
+    name = "load_visibility_test",
+    srcs = ["load_visibility_test.py"],
+    args = ["$(rootpaths //devicetree/private:all_bzl_files)"],
+    data = ["//devicetree/private:all_bzl_files"],
+)

--- a/devicetree/tests/load_visibility_test/load_visibility_test.py
+++ b/devicetree/tests/load_visibility_test/load_visibility_test.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import unittest
+import pathlib
+import sys
+
+arguments: argparse.Namespace
+
+
+def load_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("bzl_files", nargs="*", type=pathlib.Path)
+    args, unknown = parser.parse_known_args()
+    return args, unknown
+
+
+class BzlLoadVisibilityTest(unittest.TestCase):
+    def test_bzl_files_have_load_visibility(self):
+        for bzl_file in arguments.bzl_files:
+            with self.subTest(bzl_file=bzl_file):
+                with bzl_file.open() as f:
+                    has_visibility = any([line.startswith("visibility(")
+                                          for line in f.readlines()])
+                    self.assertTrue(has_visibility,
+                                    f"File {bzl_file} does not have visibility")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(levelname)s: %(message)s"
+    )
+    arguments, unknown = load_arguments()
+    sys.argv[1:] = unknown
+    unittest.main()

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,16 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Public API re-exports
+
+<a id="example"></a>
+
+## example
+
+<pre>
+example()
+</pre>
+
+This is an example
+
+
+


### PR DESCRIPTION
The default load visibility is public, which is not suitable for
//private. This test ensures that all our .bzl files under //private
must have a visibility() statement.
    
Caveat: This does not include sub-packages below private.
    
fixes #2