### PR TITLE
Update buildifier_prebuilt to 8.2.0.2.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,7 +38,7 @@ bazel_dep(name = "rules_cc", version = "0.0.16")
 bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.4", dev_dependency = True)
-bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
 bazel_dep(name = "rules_python", version = "1.5.0", dev_dependency = True)
 
 autodetected_toolchain_repo = use_repo_rule("//devicetree/private:autodetected_toolchain_repo.bzl", "autodetected_toolchain_repo")


### PR DESCRIPTION
Needed for #19 to update to Bazel 8.