### PR TITLE
fix(rules): Use preprocess_assemble action to find preprocessor.

### DIFF
--- a/devicetree/private/BUILD.bazel
+++ b/devicetree/private/BUILD.bazel
@@ -36,7 +36,9 @@ bzl_library(
         ":devicetree_library_info",
         ":utils",
         "@bazel_skylib//lib:paths",
+        "@rules_cc//cc:action_names_bzl",
         "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_cc//cc/common",
     ],
 )
 

--- a/docs/configuring_toolchain.md
+++ b/docs/configuring_toolchain.md
@@ -150,6 +150,10 @@ In `*.dts` and `*.dtso`, to support C preprocessor directives like
     [Bazel Tutorial: Configure C++ Toolchains](https://bazel.build/tutorials/ccp-toolchain-config)
     for details.
 
+    If you are using a custom C toolchain, ensure that you have registered a
+    tool via `action_config()` for the `ACTION_NAMES.preprocessor_assemble`
+    action.
+
 Example:
 
 ```


### PR DESCRIPTION
... instead of using preprocessor_executable. The latter relies on tool_path() and is already deprecated per
https://github.com/bazelbuild/bazel/issues/8438.