### PR TITLE
Revert "ci(github-actions): stops auto-publishing for now."

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,8 +31,6 @@ jobs:
       # We don't need to run tests; `needs: ci` above already does this.
       bazel_test_command: true
   publish:
-    # TODO: #5 - re-enable auto-publishing after release
-    if: false
     needs: release
     uses: ./.github/workflows/publish.yaml
     with:


### PR DESCRIPTION
This reverts commit 732a5cc682319d13a1b2b2646030c8a00b52c287.

Enables auto publishing.