### PR TITLE
Revert "Revert "ci(github-actions): stops auto-publishing for now.""

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,8 @@ jobs:
       # We don't need to run tests; `needs: ci` above already does this.
       bazel_test_command: true
   publish:
+    # TODO: #5 - re-enable auto-publishing after release
+    if: false
     needs: release
     uses: ./.github/workflows/publish.yaml
     with:


### PR DESCRIPTION
Reverts bazel-contrib/rules_devicetree#49

https://github.com/bazelbuild/bazel-central-registry/pull/5315 fails presubmit because:

- missing maintainers
- missing explicit version in MODULE.bazel