### PR TITLE
Attempt to fix BCR presubmit.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
-    platform: ["debian10", "ubuntu2004"]
+    platform: ["debian11", "ubuntu2004"]
     bazel: ["8.x", "7.x"]
   tasks:
     run_tests:
@@ -10,6 +10,6 @@ bcr_test_module:
       bazel: ${{ bazel }}
       shell_commands:
         - sudo apt-get update
-        - sudo apt-get install device-tree-compiler
+        - sudo apt-get install -y device-tree-compiler
       test_targets:
         - "//..."


### PR DESCRIPTION
Update to debian 11 because debian 10 is too old and can't run apt update.

Add -y to apt install to prevent stall.

#5